### PR TITLE
fix(podspec, leveldb): use subspecs to explicitly exclude leveldb

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,28 +1,31 @@
 firebase_firestore_version = '7.11.0'
 
 Pod::Spec.new do |s|
-  s.name             = 'FirebaseFirestore'
-  s.version          = firebase_firestore_version
-  s.summary          = 'A replica Firebase Firestore podspec.'
-  s.description      = 'A replica Firebase Firestore podspec that provides pre-compiled binaries/frameworks instead'
-  s.homepage         = 'http://invertase.io'
-  s.license          = 'Apache-2.0'
-  s.source           = { :path => '.' }
-  s.cocoapods_version = '>= 1.10.0'
-  s.authors          = 'Invertase Limited'
-  s.vendored_frameworks = 'FirebaseFirestore/*.xcframework'
-  s.preserve_paths      = 'FirebaseFirestore/*.xcframework'
-  s.resource            = 'FirebaseFirestore/Resources/*.bundle'
-  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
-  s.static_framework = true
+  s.name                   = 'FirebaseFirestore'
+  s.version                = firebase_firestore_version
+  s.summary                = 'A replica Firebase Firestore podspec.'
+  s.description            = 'A replica Firebase Firestore podspec that provides pre-compiled binaries/frameworks instead'
+  s.homepage               = 'http://invertase.io'
+  s.license                = 'Apache-2.0'
+  s.source                 = { :path => '.' }
+  s.cocoapods_version      = '>= 1.10.0'
+  s.authors                = 'Invertase Limited'
+  s.vendored_frameworks    = 'FirebaseFirestore/*.xcframework'
+  s.preserve_paths         = 'FirebaseFirestore/*.xcframework'
+  s.resource               = 'FirebaseFirestore/Resources/*.bundle'
+  s.pod_target_xcconfig    = { 'OTHER_LDFLAGS' => '-lObjC' }
+  s.static_framework       = true
 
-  # These frameworks and the c++ library are here from, and copied specifically to match, the upstream podspec:
+  # These frameworks, minimums, and the c++ library are here from, and copied specifically to match, the upstream podspec:
   # https://github.com/firebase/firebase-ios-sdk/blob/34c4bdbce23f5c6e739bda83b71ba592d6400cd5/FirebaseFirestore.podspec#L103
   # They may need updating periodically.
-  s.ios.frameworks = 'SystemConfiguration', 'UIKit'
-  s.osx.frameworks = 'SystemConfiguration'
-  s.tvos.frameworks = 'SystemConfiguration', 'UIKit'
-  s.library = 'c++'
+  s.ios.frameworks         = 'SystemConfiguration', 'UIKit'
+  s.osx.frameworks         = 'SystemConfiguration'
+  s.tvos.frameworks        = 'SystemConfiguration', 'UIKit'
+  s.library                = 'c++'
+  s.ios.deployment_target  = '10.0'
+  s.osx.deployment_target  = '10.12'
+  s.tvos.deployment_target = '10.0'
 
   # Skip leveldb framework if Firebase Database is included in any form 
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)

--- a/README.md
+++ b/README.md
@@ -41,14 +41,23 @@ Integrating is as simple as adding 1 line to your main target in your projects `
 
 
 ```ruby
-pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '6.26.0'
+pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '7.11.0'
 ```
 
-> **⚠️ Note:** where the tag says `6.26.0` this should be changed to the pod version of `Firebase/Firestore` that you or your dependencies are using - in the format `X.X.X`, for FlutterFire the version that is being used can be seen [here](https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb), for React Native Firebase [here](https://github.com/invertase/react-native-firebase/blob/master/packages/app/package.json#L70). If no version is specified on your current `Firebase/Firestore` pod then you can omit `, :tag => '6.26.0'` from the line above and use the latest version on master.
+> **⚠️ Note:** where the tag says `7.11.0` this should be changed to the pod version of `Firebase/Firestore` that you or your dependencies are using - in the format `X.X.X`, for FlutterFire the version that is being used can be seen [here](https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb), for React Native Firebase [here](https://github.com/invertase/react-native-firebase/blob/master/packages/app/package.json#L70). If no version is specified on your current `Firebase/Firestore` pod then you can omit `, :tag => '7.11.0'` from the line above and use the latest version on master.
 
 The first time you `pod install` a specific version, CocoaPods will remotely retrieve this git repository at the specifed tag and cache it locally for use as a source for the `FirebaseFirestore` pod.
 
 > **⚠️ Note:** if you were previously caching iOS builds on CI you may now find that when using precompiled binaries that caching is no longer required and it may actually slow down your build times by several minutes. 
+
+### Resolving 'leveldb' missing or duplicate symbol errors
+
+The "leveldb" framework is needed by FirebaseFirestore but may be included in other libraries, so it needs to be included or excluded correctly.
+The podspec here attempts to do that for you automatically by default, by detecting known situations where it should be excluded, but sometimes auto-detection fails.
+
+If your build fails due with duplicate 'leveldb' symbols, `pod FirebaseFirestore/WithoutLeveldb` as the pod name instead of `pod FirebaseFirestore`, reinstall pods and try rebuilding.
+
+If your build fails due with missing 'leveldb' symbols, `pod FirebaseFirestore/WithLeveldb` as the pod name instead of `pod FirebaseFirestore`, reinstall pods and try rebuilding.
 
 ### Supported Firebase iOS SDK versions
 


### PR DESCRIPTION
I still struggle with flaky builds based on the auto-exclusion of leveldb
I've split it into subspecs successfully now so you can include the `/NoLeveldb` subspec
and deterministically avoid it

Fixes #2 (again)

Patterned this off the subspec style I saw in FirebaseAnalytics to either get a default with Ad Ids or to offer a subspec that excludes them, it seemed similar and when I tried it, it worked...

I worked a lot on the messaging so it was as non-spammy as possible but also led directly to actionable troubleshooting / fix if bulid failures ocurred.

Test plan is integration into:
- react-native-tests project (which uses RTDB and Firestore so should exclude)
  - check works (mostly) auto - locally (flakes sometimes but it is possible!) :heavy_check_mark:  
  - check works locally with exclude subspec: :heavy_check_mark: 
  - check works in CI with exclude subspec :heavy_check_mark: 
- my work app (only uses Firestore so needs leveldb)
  - check that it fails if you use exclude subspec, since work app needs leveldb: :heavy_check_mark: 
  - check works with default spec: :heavy_check_mark: : 