### PR TITLE
build: only run scheduled build workflow on main repo not forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   latest_release:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'invertase/firestore-ios-sdk-frameworks' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+
     name: 'Latest Release'
     timeout-minutes: 10
     runs-on: macos-latest


### PR DESCRIPTION
noticed this when I got a github actions run failure on my fork and I was like :thinking:  oh yeah, should only run the scheduled build on main repo