### PR TITLE
fix: download assets using 302 redirect directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     name: "Latest Release"
     timeout-minutes: 10
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - name: GIT Setup

--- a/.github/workflows/scripts/process-latest-version.sh
+++ b/.github/workflows/scripts/process-latest-version.sh
@@ -14,7 +14,7 @@ pod spec which Firebase
 
 FIREBASE_GITHUB_REPOSITORY=firebase/firebase-ios-sdk
 LATEST_FIREBASE_PODSPEC=$(pod spec which Firebase)
-LATEST_FIREBASE_VERSION=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["version"])' <"$LATEST_FIREBASE_PODSPEC")
+LATEST_FIREBASE_VERSION=$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["version"])' <"$LATEST_FIREBASE_PODSPEC")
 echo "LATEST_FIREBASE_VERSION=$LATEST_FIREBASE_VERSION" >> "$GITHUB_ENV"
 
 # -------------------
@@ -50,7 +50,7 @@ create_github_release() {
     --data "$body" \
     -s)
 
-  created=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', sys.stdin))")
+  created=$(echo "$response" | python3 -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', sys.stdin))")
   if [ "$created" != "$response" ]; then
     echo "Release created successfully!"
   else
@@ -77,11 +77,11 @@ get_github_release_by_tag() {
     --header 'Content-Type: application/json' \
     -s)
 
-  release_id=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', 'Not Found'))")
+  release_id=$(echo "$response" | python3 -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', 'Not Found'))")
   if [ "$release_id" != "Not Found" ]; then
     echo "$response"
   else
-    response_message=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('message'))")
+    response_message=$(echo "$response" | python3 -c "import sys, json; data = json.load(sys.stdin); print(data.get('message'))")
     if [ "$response_message" != "Not Found" ]; then
       echo "Failed to query release '$release_name' -> GitHub API request failed with response: $response_message"
       echo "$response"
@@ -115,7 +115,7 @@ if [[ -n "$framework_repo_release" ]]; then
   exit 0
 fi
 
-firebase_firestore_version=$(python -c 'import json,sys; print(next((x for x in json.loads(sys.stdin.read())["subspecs"] if x["name"] == "Firestore"), None)["dependencies"]["FirebaseFirestore"][0])' <"$LATEST_FIREBASE_PODSPEC")
+firebase_firestore_version=$(python3 -c 'import json,sys; print(next((x for x in json.loads(sys.stdin.read())["subspecs"] if x["name"] == "Firestore"), None)["dependencies"]["FirebaseFirestore"][0])' <"$LATEST_FIREBASE_PODSPEC")
 # Sanity check we actually got the subspec version value as it should look something like `~> 1.15.0`
 if [[ "$firebase_firestore_version" != '~>'* ]]; then
   echo ""

--- a/.github/workflows/scripts/process-latest-version.sh
+++ b/.github/workflows/scripts/process-latest-version.sh
@@ -160,26 +160,8 @@ if [[ "$firebase_ios_repo_release" != *".zip"* ]]; then
   exit 1
 fi
 
-firebase_release_archive=$(echo "$firebase_ios_repo_release" | python -c 'import json,sys; print(json.loads(sys.stdin.read())["assets"][0]["browser_download_url"])')
-echo "Found archive asset, extracting direct download url from url $firebase_release_archive ..."
-
-redirect_url_html=$(curl -sS --fail "$firebase_release_archive")
-redirect_url=$(echo "$redirect_url_html" | cut -d'"' -f 2)
-if [[ "$redirect_url" != 'https://'* ]]; then
-  echo ""
-  echo "Redirect response HTML:"
-  echo "$redirect_url_html"
-  echo ""
-  echo "Attempted extraction URL:"
-  echo "$redirect_url"
-  echo ""
-  echo "Error: could not extract download url from GitHub asset redirect response."
-  exit 1
-fi
-
-# A quick and dirty URL unescape
-# shellcheck disable=SC2001
-redirect_url=$(echo "$redirect_url" | sed 's/\&amp\;/\&/g')
+firebase_release_archive=$(echo "$firebase_ios_repo_release" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["assets"][0]["browser_download_url"])')
+echo "Found archive asset, downloading from url $firebase_release_archive ..."
 
 # Create .tmp directory to download and extract binaries from
 mkdir -p .tmp
@@ -189,13 +171,7 @@ mkdir -p .tmp
 rm -rf .tmp/Firebase
 
 # Download the zip
-echo ""
-echo "Extracted asset redirect URL:"
-echo "$redirect_url"
-echo ""
-echo "Downloading asset..."
-echo ""
-curl --fail "$redirect_url" > .tmp/Firebase.zip
+curl --fail --location "$firebase_release_archive" > .tmp/Firebase.zip
 
 echo "Download successful, extracting archive..."
 unzip -q .tmp/Firebase.zip 'Firebase/FirebaseFirestore/*' -d .tmp/


### PR DESCRIPTION

For some reason all of the github asset URL discovery -> actual download location parsing stuff broke, and was reproducibly broken locally

But using curl to follow the redirect directly (via --location param) worked fine, so going with that

Also forward-ported to python3 / macos12 while I was in there

Fixes #49 