### PR TITLE
fix(firestore, ios): exclude relevant architecture

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -12,7 +12,10 @@ Pod::Spec.new do |s|
   s.authors                = 'Invertase Limited'
   s.pod_target_xcconfig    = { 'OTHER_LDFLAGS' => '-lObjC' }
   s.static_framework       = true
-
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   # These frameworks, minimums, and the c++ library are here from, and copied specifically to match, the upstream podspec:
   # https://github.com/firebase/firebase-ios-sdk/blob/34c4bdbce23f5c6e739bda83b71ba592d6400cd5/FirebaseFirestore.podspec#L103
   # They may need updating periodically.


### PR DESCRIPTION
With 9.2.0 onwards this is happening without this chage:

```
Xcode's output:
↳
    Writing result bundle at path:
    	/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/flutter_tools.8UFPl6/flutter_ios_build_temp_diryBNGa1/temporary_xcresult_bundle
    warning: [CP] BoringSSL-GRPC.xcframework: Unable to find matching slice in 'ios-arm64 ios-arm64_x[86](https://github.com/firebase/flutterfire/runs/7094273749?check_suite_focus=true#step:9:87)_64-maccatalyst ios-arm64_x86_64-simulator' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] FirebaseFirestore.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-simulator ios-arm64_x86_64-maccatalyst ios-arm64' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] FirebaseFirestoreSwift.xcframework: Unable to find matching slice in 'ios-arm64 ios-arm64_x86_64-maccatalyst ios-arm64_x86_64-simulator' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] Libuv-gRPC.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-simulator ios-arm64 ios-arm64_x86_64-maccatalyst' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] abseil.xcframework: Unable to find matching slice in 'ios-arm64 ios-arm64_x86_64-simulator ios-arm64_x86_64-maccatalyst' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] gRPC-C++.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-simulator ios-arm64 ios-arm64_x86_64-maccatalyst' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] gRPC-Core.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-maccatalyst ios-arm64_x86_64-simulator ios-arm64' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:38: warning: 'UNMutableNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
                                         ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:[97](https://github.com/firebase/flutterfire/runs/7094273749?check_suite_focus=true#step:9:98):12: note: 'UNMutableNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNMutableNotificationContent : UNNotificationContent
               ^
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:1: note: annotate 'populateNotificationContent:withContentHandler:' with an availability attribute to silence this warning
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
    ^
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:38:47: warning: 'UNNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
                     withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
                                                  ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:37:12: note: 'UNNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNNotificationContent : NSObject <NSCopying, NSMutableCopying, NSSecureCoding>
               ^
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:1: note: annotate 'populateNotificationContent:withContentHandler:' with an availability attribute to silence this warning
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
    ^
    2 warnings generated.
    2 warnings generated.
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:38: warning: 'UNMutableNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
                                         ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:97:12: note: 'UNMutableNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNMutableNotificationContent : UNNotificationContent
               ^
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:1: note: annotate 'populateNotificationContent:withContentHandler:' with an availability attribute to silence this warning
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
    ^
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:38:47: warning: 'UNNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
                     withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
                                                  ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:37:12: note: 'UNNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNNotificationContent : NSObject <NSCopying, NSMutableCopying, NSSecureCoding>
               ^
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:1: note: annotate 'populateNotificationContent:withContentHandler:' with an availability attribute to silence this warning
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
    ^
    2 warnings generated.
    2 warnings generated.
    Command CompileSwiftSources failed with a nonzero exit code
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:38: warning: 'UNMutableNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
                                         ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:97:12: note: 'UNMutableNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNMutableNotificationContent : UNNotificationContent
               ^
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:1: note: annotate 'populateNotificationContent:withContentHandler:' with an availability attribute to silence this warning
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
    ^
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:38:47: warning: 'UNNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
                     withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler;
                                                  ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:37:12: note: 'UNNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNNotificationContent : NSObject <NSCopying, NSMutableCopying, NSSecureCoding>
               ^
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:1: note: annotate 'populateNotificationContent:withContentHandler:' with an availability attribute to silence this warning
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
    ^
    2 warnings generated.
    2 warnings generated.
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:38: warning: 'UNMutableNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
                                         ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:Xcode's output:
↳
    Writing result bundle at path:
    	/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/flutter_tools.8UFPl6/flutter_ios_build_temp_diryBNGa1/temporary_xcresult_bundle
    warning: [CP] BoringSSL-GRPC.xcframework: Unable to find matching slice in 'ios-arm64 ios-arm64_x[86](https://github.com/firebase/flutterfire/runs/7094273749?check_suite_focus=true#step:9:87)_64-maccatalyst ios-arm64_x86_64-simulator' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] FirebaseFirestore.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-simulator ios-arm64_x86_64-maccatalyst ios-arm64' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] FirebaseFirestoreSwift.xcframework: Unable to find matching slice in 'ios-arm64 ios-arm64_x86_64-maccatalyst ios-arm64_x86_64-simulator' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] Libuv-gRPC.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-simulator ios-arm64 ios-arm64_x86_64-maccatalyst' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] abseil.xcframework: Unable to find matching slice in 'ios-arm64 ios-arm64_x86_64-simulator ios-arm64_x86_64-maccatalyst' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] gRPC-C++.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-simulator ios-arm64 ios-arm64_x86_64-maccatalyst' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    warning: [CP] gRPC-Core.xcframework: Unable to find matching slice in 'ios-arm64_x86_64-maccatalyst ios-arm64_x86_64-simulator ios-arm64' for the current build architectures (arm64 x86_64 i386) and platform (-iphonesimulator).
    While building module 'FirebaseMessaging' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Headers/Public/Firebase/Firebase.h:66:
    In file included from <module-includes>:1:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/Target Support Files/FirebaseMessaging/FirebaseMessaging-umbrella.h:13:
    In file included from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FirebaseMessaging.h:18:
    /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:37:38: warning: 'UNMutableNotificationContent' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - (void)populateNotificationContent:(UNMutableNotificationContent *)content
                                         ^
    In module 'UserNotifications' imported from /Users/runner/work/flutterfire/flutterfire/tests/ios/Pods/FirebaseMessaging/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessagingExtensionHelper.h:22:
    /Applications/Xcode_13.3.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.4.sdk/System/Library/Frameworks/UserNotifications.framework/Headers/UNNotificationContent.h:[97](https://github.com/firebase/flutterfire/runs/7094273749?check_suite_focus=true#step:9:98):12: note: 'UNMutableNotificationContent' has been marked as being introduced in iOS 10.0 here, but the deployment target is iOS 9.0.0
    @interface UNMutableNotificationContent : UNNotificationContent
               ^
    While building module 'FirebaseMessaging' imported from 
...
```