### PR TITLE
remove min mac for nanopb

### DIFF
--- a/.github/workflows/scripts/extract-versions.sh
+++ b/.github/workflows/scripts/extract-versions.sh
@@ -18,8 +18,8 @@ firebase_firestore_version=$(python3 -c 'import json; data = json.load(open("'"$
 
 # Extract gRPC version
 firebase_firestore_grpc_version=$(python3 -c 'import json; data = json.load(open("'"$PODSPEC_FILE"'")); print(data["dependencies"]["gRPC-C++"][0].replace("~> ", ""))')
-# If the gRPC version is 1.62.0, set it to 1.62.1
-# Since the tag is missing for 1.62.0.
+# If the gRPC version is 1.65.0, set it to 1.65.1
+# Since the tag is missing for 1.65.0.
 if [ "$firebase_firestore_grpc_version" = "1.65.0" ]; then
   echo "Overriding gRPC version to 1.65.1"
   firebase_firestore_grpc_version="1.65.1"
@@ -29,10 +29,7 @@ fi
 firebase_firestore_leveldb_version=$(python3 -c 'import json; data = json.load(open("'"$PODSPEC_FILE"'")); print(data["dependencies"]["leveldb-library"][0])')
 
 # Extract nanopb minimum version
-firebase_firestore_nanopb_version_min=$(python3 -c 'import json; data = json.load(open("'"$PODSPEC_FILE"'")); print(data["dependencies"]["nanopb"][0])')
-
-# Extract nanopb maximum version
-firebase_firestore_nanopb_version_max=$(python3 -c 'import json; data = json.load(open("'"$PODSPEC_FILE"'")); print(data["dependencies"]["nanopb"][1])')
+firebase_firestore_nanopb_version=$(python3 -c 'import json; data = json.load(open("'"$PODSPEC_FILE"'")); print(data["dependencies"]["nanopb"][0])')
 
 # URL of the grpc binary Package.swift file
 grpc_binary_swift_url="https://raw.githubusercontent.com/google/grpc-binary/$firebase_firestore_grpc_version/Package.swift"
@@ -83,13 +80,8 @@ if [ -z "$firebase_firestore_leveldb_version" ]; then
   exit 1
 fi
 
-if [ -z "$firebase_firestore_nanopb_version_min" ]; then
-  echo "Failed to extract Firebase Firestore nanopb minimum version from podspec."
-  exit 1
-fi
-
-if [ -z "$firebase_firestore_nanopb_version_max" ]; then
-  echo "Failed to extract Firebase Firestore nanopb maximum version from podspec."
+if [ -z "$firebase_firestore_nanopb_version" ]; then
+  echo "Failed to extract Firebase Firestore nanopb version from podspec."
   exit 1
 fi
 
@@ -104,8 +96,7 @@ cat <<EOF > $json_file_write_path
   "firebase_firestore_version": "$firebase_firestore_version",
   "firebase_firestore_grpc_version": "$firebase_firestore_grpc_version",
   "firebase_firestore_leveldb_version": "$firebase_firestore_leveldb_version",
-  "firebase_firestore_nanopb_version_min": "$firebase_firestore_nanopb_version_min",
-  "firebase_firestore_nanopb_version_max": "$firebase_firestore_nanopb_version_max",
+  "firebase_firestore_nanopb_version": "$firebase_firestore_nanopb_version",
   "firebase_firestore_abseil_version": "$firebase_firestore_abseil_version"
 }
 EOF

--- a/.github/workflows/scripts/framework-controller.dart
+++ b/.github/workflows/scripts/framework-controller.dart
@@ -117,8 +117,7 @@ Future<void> main() async {
       versions.firebase_firestore_abseil_version,
       versions.firebase_firestore_grpc_version,
       versions.firebase_firestore_leveldb_version,
-      versions.firebase_firestore_nanopb_version_min,
-      versions.firebase_firestore_nanopb_version_max,
+      versions.firebase_firestore_nanopb_version,
       createURLToZip(
         'grpc',
         versions.firebase_firestore_version,

--- a/.github/workflows/scripts/update-file-variables.sh
+++ b/.github/workflows/scripts/update-file-variables.sh
@@ -4,13 +4,12 @@ firebase_firestore_version=$1
 firebase_firestore_abseil_version=$2
 firebase_firestore_grpc_version=$3
 firebase_firestore_leveldb_version=$4
-firebase_firestore_nanopb_version_min=$5
-firebase_firestore_nanopb_version_max=$6
-firebase_firestore_grpc_version_url=$7
-firebase_firestore_abseil_url=$8
-firebase_firestore_internal_url=$9
-firebase_firestore_grpc_boringssl_url=${10}
-firebase_firestore_grpc_ccp_version_url=${11}
+firebase_firestore_nanopb_version=$5
+firebase_firestore_grpc_version_url=$6
+firebase_firestore_abseil_url=$7
+firebase_firestore_internal_url=$8
+firebase_firestore_grpc_boringssl_url=${9}
+firebase_firestore_grpc_ccp_version_url=${10}
 
 # UPDATE THE VARIABLES IN EACH PODSPEC FILE
 for file in *.podspec; do
@@ -18,8 +17,7 @@ for file in *.podspec; do
   sed -i '' "s|firebase_firestore_abseil_version[[:space:]]*=[[:space:]]*.*|firebase_firestore_abseil_version='$firebase_firestore_abseil_version'|" "$file"
   sed -i '' "s|firebase_firestore_grpc_version[[:space:]]*=[[:space:]]*.*|firebase_firestore_grpc_version='$firebase_firestore_grpc_version'|" "$file"
   sed -i '' "s|firebase_firestore_leveldb_version[[:space:]]*=[[:space:]]*.*|firebase_firestore_leveldb_version='$firebase_firestore_leveldb_version'|" "$file"
-  sed -i '' "s|firebase_firestore_nanopb_version_min[[:space:]]*=[[:space:]]*.*|firebase_firestore_nanopb_version_min='$firebase_firestore_nanopb_version_min'|" "$file"
-  sed -i '' "s|firebase_firestore_nanopb_version_max[[:space:]]*=[[:space:]]*.*|firebase_firestore_nanopb_version_max='$firebase_firestore_nanopb_version_max'|" "$file"
+  sed -i '' "s|firebase_firestore_nanopb_version[[:space:]]*=[[:space:]]*.*|firebase_firestore_nanopb_version='$firebase_firestore_nanopb_version'|" "$file"
   sed -i '' "s|firebase_firestore_abseil_url[[:space:]]*=[[:space:]]*.*|firebase_firestore_abseil_url='$firebase_firestore_abseil_url'|" "$file"
   sed -i '' "s|firebase_firestore_grpc_ccp_version_url[[:space:]]*=[[:space:]]*.*|firebase_firestore_grpc_ccp_version_url='$firebase_firestore_grpc_ccp_version_url'|" "$file"
   sed -i '' "s|firebase_firestore_grpc_version_url[[:space:]]*=[[:space:]]*.*|firebase_firestore_grpc_version_url='$firebase_firestore_grpc_version_url'|" "$file"

--- a/.github/workflows/scripts/utils.dart
+++ b/.github/workflows/scripts/utils.dart
@@ -8,16 +8,14 @@ class FirestoreVersions {
     required this.firebase_firestore_version,
     required this.firebase_firestore_grpc_version,
     required this.firebase_firestore_leveldb_version,
-    required this.firebase_firestore_nanopb_version_min,
-    required this.firebase_firestore_nanopb_version_max,
+    required this.firebase_firestore_nanopb_version,
     required this.firebase_firestore_abseil_version,
   });
 
   final String firebase_firestore_version;
   final String firebase_firestore_grpc_version;
   final String firebase_firestore_leveldb_version;
-  final String firebase_firestore_nanopb_version_min;
-  final String firebase_firestore_nanopb_version_max;
+  final String firebase_firestore_nanopb_version;
   final String firebase_firestore_abseil_version;
 }
 
@@ -70,10 +68,8 @@ Future<FirestoreVersions> getVersions(String filePath) async {
         jsonData['firebase_firestore_grpc_version'],
     firebase_firestore_leveldb_version:
         jsonData['firebase_firestore_leveldb_version'],
-    firebase_firestore_nanopb_version_min:
-        jsonData['firebase_firestore_nanopb_version_min'],
-    firebase_firestore_nanopb_version_max:
-        jsonData['firebase_firestore_nanopb_version_max'],
+    firebase_firestore_nanopb_version:
+        jsonData['firebase_firestore_nanopb_version'],
     firebase_firestore_abseil_version:
         jsonData['firebase_firestore_abseil_version'],
   );


### PR DESCRIPTION
`nanopb` is now described like that:
```{
  "name": "FirebaseFirestoreInternal",
  "version": "11.0.0",
  "summary": "Google Cloud Firestore",
  "description": "Google Cloud Firestore is a NoSQL document database built for automatic scaling, high performance, and ease of application development.",
  "homepage": "https://developers.google.com/",
  "license": {
    "type": "Apache-2.0",
    "file": "Firestore/LICENSE"
  },
  "authors": "Google, Inc.",
  "source": {
    "git": "https://github.com/firebase/firebase-ios-sdk.git",
    "tag": "CocoaPods-11.0.0"
  },
  "platforms": {
    "ios": "13.0",
    "osx": "10.15",
    "tvos": "13.0"
  },
  "swift_versions": "5.9",
  "cocoapods_version": ">= 1.12.0",
  "prefix_header_file": false,
  "public_header_files": "Firestore/Source/Public/FirebaseFirestore/*.h",
  "source_files": [
    "FirebaseCore/Extension/*.h",
    "Firestore/Source/Public/FirebaseFirestore/*.h",
    "Firestore/Source/**/*.{m,mm}",
    "Firestore/Protos/nanopb/**/*.cc",
    "Firestore/core/include/**/*.{cc,mm}",
    "Firestore/core/src/**/*.{cc,mm}",
    "FirebaseAuth/Interop/**/*.h"
  ],
  "preserve_paths": [
    "Firestore/Source/API/*.h",
    "Firestore/Source/Core/*.h",
    "Firestore/Source/Local/*.h",
    "Firestore/Source/Remote/*.h",
    "Firestore/Source/Util/*.h",
    "Firestore/Protos/nanopb/**/*.h",
    "Firestore/core/include/**/*.h",
    "Firestore/core/src/**/*.h",
    "Firestore/third_party/nlohmann_json/json.hpp"
  ],
  "requires_arc": [
    "Firestore/Source/**/*",
    "Firestore/core/src/**/*.mm"
  ],
  "exclude_files": [
    "Firestore/core/src/api/input_validation_std.cc",
    "Firestore/core/src/remote/connectivity_monitor_noop.cc",
    "Firestore/core/src/util/filesystem_win.cc",
    "Firestore/core/src/util/hard_assert_stdio.cc",
    "Firestore/core/src/util/log_stdio.cc",
    "Firestore/core/src/util/secure_random_openssl.cc"
  ],
  "resource_bundles": {
    "FirebaseFirestoreInternal_Privacy": "Firestore/Source/Resources/PrivacyInfo.xcprivacy"
  },
  "dependencies": {
    "FirebaseAppCheckInterop": [
      "~> 11.0"
    ],
    "FirebaseCore": [
      "~> 11.0"
    ],
    "abseil/algorithm": [
      "~> 1.20240116.1"
    ],
    "abseil/base": [
      "~> 1.20240116.1"
    ],
    "abseil/container/flat_hash_map": [
      "~> 1.20240116.1"
    ],
    "abseil/memory": [
      "~> 1.20240116.1"
    ],
    "abseil/meta": [
      "~> 1.20240116.1"
    ],
    "abseil/strings/strings": [
      "~> 1.20240116.1"
    ],
    "abseil/time": [
      "~> 1.20240116.1"
    ],
    "abseil/types": [
      "~> 1.20240116.1"
    ],
    "gRPC-Core": [
      "~> 1.65.0"
    ],
    "gRPC-C++": [
      "~> 1.65.0"
    ],
    "leveldb-library": [
      "~> 1.22"
    ],
    "nanopb": [
      "~> 3.30910.0"
    ]
  },
  "ios": {
    "frameworks": [
      "SystemConfiguration",
      "UIKit"
    ]
  },
  "osx": {
    "frameworks": "SystemConfiguration"
  },
  "tvos": {
    "frameworks": [
      "SystemConfiguration",
      "UIKit"
    ]
  },
  "libraries": "c++",
  "pod_target_xcconfig": {
    "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
    "CLANG_CXX_LIBRARY": "libc++",
    "GCC_C_LANGUAGE_STANDARD": "c99",
    "GCC_PREPROCESSOR_DEFINITIONS": "FIRFirestore_VERSION=11.0.0 PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1",
    "HEADER_SEARCH_PATHS": "\"${PODS_TARGET_SRCROOT}\" \"${PODS_TARGET_SRCROOT}/Firestore/Source/Public\" \"${PODS_ROOT}/nanopb\" \"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb\""
  },
  "compiler_flags": "$(inherited) -Wreorder -Werror=reorder -Wno-comma",
  "swift_version": "5.9"
}
```