### PR TITLE
Update flutterfire repo branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Integrating is as simple as adding 1 line to your main target in your projects `
 pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.19.0'
 ```
 
-> **⚠️ Note:** where the tag says `10.19.0` this should be changed to the pod version of `Firebase/Firestore` that you or your dependencies are using - in the format `X.X.X`, for FlutterFire the version that is being used can be seen [here](https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb), for React Native Firebase [here](https://github.com/invertase/react-native-firebase/blob/master/packages/app/package.json#L70). If no version is specified on your current `Firebase/Firestore` pod then you can omit `, :tag => '10.19.0'` from the line above and use the latest version on master.
+> **⚠️ Note:** where the tag says `10.19.0` this should be changed to the pod version of `Firebase/Firestore` that you or your dependencies are using - in the format `X.X.X`, for FlutterFire the version that is being used can be seen [here](https://github.com/FirebaseExtended/flutterfire/blob/main/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb), for React Native Firebase [here](https://github.com/invertase/react-native-firebase/blob/master/packages/app/package.json#L70). If no version is specified on your current `Firebase/Firestore` pod then you can omit `, :tag => '10.19.0'` from the line above and use the latest version on master/main.
 
 The first time you `pod install` a specific version, CocoaPods will remotely retrieve this git repository at the specified tag and cache it locally for use as a source for the `FirebaseFirestore` pod.
 


### PR DESCRIPTION
The flutterfire repo has moved to use main (instead of master): https://github.com/firebase/flutterfire/branches

This PR updates the README link to point to the active branch.