### PR TITLE
fix: de-flake release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Process Latest Version
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          dart ./.github/workflows/scripts/framework-controller.dart
+        run: dart ./.github/workflows/scripts/framework-controller.dart
       - name: Report Failure Status
         uses: slackapi/slack-github-action@v2
         if: failure()
@@ -42,4 +41,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "https://github.com/invertase/firestore-ios-sdk-frameworks build failure: ${{ env.LATEST_FIREBASE_VERSION }} {{ job.status }}"
+            text: "https://github.com/invertase/firestore-ios-sdk-frameworks build failure for Firebase ${{ env.LATEST_FIREBASE_VERSION }} (job status: {{ job.status }})"

--- a/.github/workflows/scripts/check-release-complete.sh
+++ b/.github/workflows/scripts/check-release-complete.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -o pipefail
+
+firebase_firestore_version=$1
+firebase_firestore_grpc_version=$2
+firebase_firestore_abseil_version=$3
+
+if [ -z "$firebase_firestore_version" ]; then
+  echo "Missing firebase_firestore_version argument."
+  exit 2
+fi
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if ! git rev-parse "$firebase_firestore_version" >/dev/null 2>&1; then
+  echo "Tag $firebase_firestore_version does not exist; release build required."
+  exit 1
+fi
+
+if ! pod repo list 2>/dev/null | grep -qE '^cocoapods$'; then
+  pod repo add cocoapods "https://github.com/CocoaPods/Specs.git"
+fi
+pod repo update cocoapods
+
+pods_to_check=(
+  "FirebaseFirestoreGRPCBoringSSLBinary:$firebase_firestore_grpc_version"
+  "FirebaseFirestoreAbseilBinary:$firebase_firestore_abseil_version"
+  "FirebaseFirestoreGRPCCoreBinary:$firebase_firestore_grpc_version"
+  "FirebaseFirestoreGRPCCPPBinary:$firebase_firestore_grpc_version"
+  "FirebaseFirestoreInternalBinary:$firebase_firestore_version"
+  "FirebaseFirestoreBinary:$firebase_firestore_version"
+)
+
+for entry in "${pods_to_check[@]}"; do
+  pod_name="${entry%%:*}"
+  pod_version="${entry##*:}"
+  if ! pod spec which "$pod_name" --version="$pod_version" >/dev/null 2>&1; then
+    echo "$pod_name ($pod_version) not on CocoaPods trunk; release build required."
+    exit 1
+  fi
+done
+
+echo "Release $firebase_firestore_version is already complete (tag and all pods exist)."
+exit 0

--- a/.github/workflows/scripts/commit-and-publish.sh
+++ b/.github/workflows/scripts/commit-and-publish.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -o pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=release-lib.sh
+source "$SCRIPT_DIR/release-lib.sh"
+
 firebase_firestore_version=$1
 firebase_firestore_grpc_version=$2
 firebase_firestore_abseil_version=$3
+
 # -------------------
 #      Functions
 # -------------------
@@ -48,14 +53,14 @@ create_github_release() {
   fi
 }
 
-if [ $(git tag -l "$firebase_firestore_version") ]; then
+if [ -n "$(git tag -l "$firebase_firestore_version")" ]; then
   echo "Tag $firebase_firestore_version already exists, skipping tagging."
 else
   # GIT COMMIT, PUSH & TAG
   new_version_added_line="<!--NEW_VERSION_PLACEHOLDER-->¬ - [$firebase_firestore_version](https:\/\/github.com\/invertase\/firestore-ios-sdk-frameworks\/releases\/tag\/$firebase_firestore_version)"
   updated_readme_contents=$(sed -e "s/<!--NEW_VERSION_PLACEHOLDER-->.*/$new_version_added_line/" README.md | tr '¬' '\n')
   echo "$updated_readme_contents" >README.md
-  
+
   git add .
   git commit -m "release: $firebase_firestore_version"
   git tag -a "$firebase_firestore_version" -m "$firebase_firestore_version"
@@ -63,112 +68,13 @@ else
   create_github_release "$firebase_firestore_version" "\"[View Firebase iOS SDK Release](https://github.com/firebase/firebase-ios-sdk/releases/tag/$firebase_firestore_version)\"" "$firebase_firestore_version"
 fi
 
-
 # PUSH THE PODSPECS TO COCOAPODS
-
-pod repo add cocoapods "https://github.com/CocoaPods/Specs.git"
-
-pod repo update
-echo "Running 'pod spec which FirebaseFirestoreGRPCBoringSSLBinary --version=$firebase_firestore_grpc_version'"
-pod spec which FirebaseFirestoreGRPCBoringSSLBinary --version="$firebase_firestore_grpc_version"
-exit_code=$?
-if [ $exit_code -eq 1 ]; then
-  pod trunk push FirebaseFirestoreGRPCBoringSSLBinary.podspec --allow-warnings --skip-tests --skip-import-validation --synchronous
-  exit_code=$?
-  sleep 5m
-  pod repo update cocoapods
-else
-  echo "FirebaseFirestoreGRPCBoringSSLBinary already exists"
-fi
-if [ $exit_code -ne 0 ]; then
-  echo "Failed to push FirebaseFirestoreGRPCBoringSSLBinary"
-  exit 1
-fi
-
-pod repo update
-echo "Running 'pod spec which FirebaseFirestoreAbseilBinary --version=$firebase_firestore_abseil_version'"
-pod spec which FirebaseFirestoreAbseilBinary --version="$firebase_firestore_abseil_version"
-exit_code=$?
-if [ $exit_code -eq 1 ]; then
-  pod trunk push FirebaseFirestoreAbseilBinary.podspec --allow-warnings --skip-tests --skip-import-validation --synchronous
-  exit_code=$?
-  sleep 5m
-  pod repo update cocoapods
-else
-  echo "FirebaseFirestoreAbseilBinary already exists"
-fi
-if [ $exit_code -ne 0 ]; then
-  echo "Failed to push FirebaseFirestoreAbseilBinary"
-  exit 1
-fi
-
-pod repo update
-echo "Running 'pod spec which FirebaseFirestoreGRPCCoreBinary --version=$firebase_firestore_grpc_version'"
-pod spec which FirebaseFirestoreGRPCCoreBinary --version="$firebase_firestore_grpc_version"
-exit_code=$?
-if [ $exit_code -eq 1 ]; then
-  pod trunk push FirebaseFirestoreGRPCCoreBinary.podspec --allow-warnings --skip-tests --skip-import-validation --synchronous
-  exit_code=$?
-  sleep 5m
-  pod repo update cocoapods
-else
-  echo "FirebaseFirestoreGRPCCoreBinary already exists"
-fi
-if [ $exit_code -ne 0 ]; then
-  echo "Failed to push FirebaseFirestoreGRPCCoreBinary"
-  exit 1
-fi
-
-pod repo update
-echo "Running 'pod spec which FirebaseFirestoreGRPCCPPBinary --version=$firebase_firestore_grpc_version'"
-pod spec which FirebaseFirestoreGRPCCPPBinary --version="$firebase_firestore_grpc_version"
-exit_code=$?
-if [ $exit_code -eq 1 ]; then
-  pod trunk push FirebaseFirestoreGRPCCPPBinary.podspec --allow-warnings --skip-tests --skip-import-validation --synchronous
-  exit_code=$?
-  sleep 5m
-  pod repo update cocoapods
-else
-  echo "FirebaseFirestoreGRPCCPPBinary already exists"
-fi
-if [ $exit_code -ne 0 ]; then
-  echo "Failed to push FirebaseFirestoreGRPCCPPBinary"
-  exit 1
-fi
-
-pod repo update
-echo "Running 'pod spec which FirebaseFirestoreInternalBinary --version=$firebase_firestore_version'"
-pod spec which FirebaseFirestoreInternalBinary --version="$firebase_firestore_version"
-exit_code=$?
-if [ $exit_code -eq 1 ]; then
-  pod trunk push FirebaseFirestoreInternalBinary.podspec --allow-warnings --skip-tests --skip-import-validation --synchronous
-  exit_code=$?
-  sleep 5m
-  pod repo update cocoapods
-else
-  echo "FirebaseFirestoreInternalBinary already exists"
-fi
-if [ $exit_code -ne 0 ]; then
-  echo "Failed to push FirebaseFirestoreInternalBinary"
-  exit 1
-fi
-
-pod repo update
-echo "Running 'pod spec which FirebaseFirestoreBinary --version=$firebase_firestore_version'"
-pod spec which FirebaseFirestoreBinary --version="$firebase_firestore_version"
-exit_code=$?
-if [ $exit_code -eq 1 ]; then
-  pod trunk push FirebaseFirestoreBinary.podspec --allow-warnings --skip-tests --skip-import-validation --synchronous
-  exit_code=$?
-else
-  echo "FirebaseFirestoreBinary already exists"
-fi
-if [ $exit_code -ne 0 ]; then
-  echo "Failed to push FirebaseFirestoreBinary"
-  exit 1
-fi
-
-
+push_pod_if_missing FirebaseFirestoreGRPCBoringSSLBinary "$firebase_firestore_grpc_version" FirebaseFirestoreGRPCBoringSSLBinary.podspec || exit 1
+push_pod_if_missing FirebaseFirestoreAbseilBinary "$firebase_firestore_abseil_version" FirebaseFirestoreAbseilBinary.podspec || exit 1
+push_pod_if_missing FirebaseFirestoreGRPCCoreBinary "$firebase_firestore_grpc_version" FirebaseFirestoreGRPCCoreBinary.podspec || exit 1
+push_pod_if_missing FirebaseFirestoreGRPCCPPBinary "$firebase_firestore_grpc_version" FirebaseFirestoreGRPCCPPBinary.podspec || exit 1
+push_pod_if_missing FirebaseFirestoreInternalBinary "$firebase_firestore_version" FirebaseFirestoreInternalBinary.podspec || exit 1
+push_pod_if_missing FirebaseFirestoreBinary "$firebase_firestore_version" FirebaseFirestoreBinary.podspec || exit 1
 
 echo ""
-echo "Release $LATEST_FIREBASE_VERSION complete."
+echo "Release $firebase_firestore_version complete."

--- a/.github/workflows/scripts/constants.dart
+++ b/.github/workflows/scripts/constants.dart
@@ -3,6 +3,7 @@ const bool debugOutput = true;
 const pathToScripts = '.github/workflows/scripts/';
 
 const String extractVersionsScript = 'extract-versions.sh';
+const String checkReleaseCompleteScript = 'check-release-complete.sh';
 const String firestoreVersionJSONPath = './tmp/firestore_versions.json';
 
 const String extractRawZipUrlsScript = 'extract-urls.sh';

--- a/.github/workflows/scripts/create-zips.sh
+++ b/.github/workflows/scripts/create-zips.sh
@@ -13,15 +13,18 @@ temp_privacy_manifest_path="./tmp/PrivacyInfo.xcprivacy"
 # Create the directory for the new ZIP file if it doesn't exist
 new_zip_dir=$(dirname "$path_to_new_zip")
 mkdir -p "$new_zip_dir"
+mkdir -p "./tmp"
+
+curl_retry_flags=(--retry 5 --retry-delay 10 --retry-all-errors)
 
 # Fetch the original ZIP file, fail if HTTP request fails (e.g., with a 404)
-if ! curl -sf "$raw_zip_url" -o "$temp_zip_path"; then
+if ! curl -sf "${curl_retry_flags[@]}" "$raw_zip_url" -o "$temp_zip_path"; then
   echo "Failed to download ZIP file (URL might be invalid or file not found)."
   exit 1
 fi
 
 # Fetch the PrivacyInfo.xcprivacy file, fail if HTTP request fails
-if ! curl -sf "$privacy_manifest_url" -o "$temp_privacy_manifest_path"; then
+if ! curl -sf "${curl_retry_flags[@]}" "$privacy_manifest_url" -o "$temp_privacy_manifest_path"; then
   echo "Failed to download PrivacyInfo.xcprivacy file (URL might be invalid or file not found)."
   exit 1
 fi

--- a/.github/workflows/scripts/extract-versions.sh
+++ b/.github/workflows/scripts/extract-versions.sh
@@ -7,8 +7,10 @@ json_file_write_path=$1
 # Update pod repo to ensure we retrieve the latest version.
 echo "Updating pods..."
 pod repo list
-pod repo add cocoapods "https://github.com/CocoaPods/Specs.git"
-pod repo update
+if ! pod repo list 2>/dev/null | grep -qE '^cocoapods$'; then
+  pod repo add cocoapods "https://github.com/CocoaPods/Specs.git"
+fi
+pod repo update cocoapods
 pod spec which FirebaseFirestoreInternal
 
 # Should be removed once the podspec is updated.
@@ -38,7 +40,7 @@ grpc_binary_swift_url="https://raw.githubusercontent.com/google/grpc-binary/$fir
 
 # Fetch the Package.swift file
 echo "Fetching Package.swift file from $grpc_binary_swift_url"
-package_swift=$(curl -s $grpc_binary_swift_url)
+package_swift=$(curl -sf --retry 5 --retry-delay 5 --retry-all-errors "$grpc_binary_swift_url")
 
 # Check if the fetch was successful
 if [[ -z $package_swift ]]; then
@@ -101,4 +103,10 @@ cat <<EOF > $json_file_write_path
   "firebase_firestore_abseil_version": "$firebase_firestore_abseil_version"
 }
 EOF
+
+if [ -n "$GITHUB_ENV" ]; then
+  echo "LATEST_FIREBASE_VERSION=$firebase_firestore_version" >> "$GITHUB_ENV"
+fi
+
+echo "Latest Firebase Firestore version: $firebase_firestore_version"
 

--- a/.github/workflows/scripts/framework-controller.dart
+++ b/.github/workflows/scripts/framework-controller.dart
@@ -25,6 +25,37 @@ Future<void> main() async {
   }
 
   final versions = await getVersions(firestoreVersionJSONPath);
+  await exportLatestFirebaseVersion(versions.firebase_firestore_version);
+
+  final releaseCompleteResults = await Process.run(
+    'bash',
+    [
+      p.join(
+        pathToScripts,
+        checkReleaseCompleteScript,
+      ),
+      versions.firebase_firestore_version,
+      versions.firebase_firestore_grpc_version,
+      versions.firebase_firestore_abseil_version,
+    ],
+  );
+
+  if (debugOutput) {
+    print(releaseCompleteResults.stdout);
+  }
+
+  if (releaseCompleteResults.exitCode == 0) {
+    print(
+      'Release ${versions.firebase_firestore_version} already complete; skipping build.',
+    );
+    return;
+  }
+
+  if (releaseCompleteResults.exitCode == 2) {
+    throw Exception(
+      'Checking release status failed: ${releaseCompleteResults.stderr}',
+    );
+  }
 
   // Step 2: Extract raw zip urls for creating our own with privacy manifests
   final rawUrlResults = await Process.run(

--- a/.github/workflows/scripts/release-lib.sh
+++ b/.github/workflows/scripts/release-lib.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+POD_TRUNK_MAX_ATTEMPTS=${POD_TRUNK_MAX_ATTEMPTS:-3}
+POD_TRUNK_RETRY_DELAY_SECONDS=${POD_TRUNK_RETRY_DELAY_SECONDS:-60}
+POD_TRUNK_POST_PUBLISH_SLEEP_SECONDS=${POD_TRUNK_POST_PUBLISH_SLEEP_SECONDS:-300}
+
+ensure_cocoapods_repo() {
+  if ! pod repo list 2>/dev/null | grep -qE '^cocoapods$'; then
+    pod repo add cocoapods "https://github.com/CocoaPods/Specs.git"
+  fi
+  pod repo update cocoapods
+}
+
+pod_exists_on_trunk() {
+  local pod_name=$1
+  local pod_version=$2
+  pod spec which "$pod_name" --version="$pod_version" >/dev/null 2>&1
+}
+
+# Pushes a podspec when missing. Verifies trunk state after each attempt so a
+# successful publish is not reported as failure when the GitHub commit API times out.
+push_pod_if_missing() {
+  local pod_name=$1
+  local pod_version=$2
+  local podspec_file=$3
+  local attempt=1
+
+  ensure_cocoapods_repo
+  echo "Running 'pod spec which $pod_name --version=$pod_version'"
+  if pod_exists_on_trunk "$pod_name" "$pod_version"; then
+    echo "$pod_name already exists"
+    return 0
+  fi
+
+  while [ $attempt -le $POD_TRUNK_MAX_ATTEMPTS ]; do
+    echo "Pushing $pod_name ($pod_version), attempt $attempt/$POD_TRUNK_MAX_ATTEMPTS"
+    pod trunk push "$podspec_file" --allow-warnings --skip-tests --skip-import-validation --synchronous || true
+
+    ensure_cocoapods_repo
+    if pod_exists_on_trunk "$pod_name" "$pod_version"; then
+      echo "$pod_name ($pod_version) confirmed on CocoaPods trunk"
+      if [ "$POD_TRUNK_POST_PUBLISH_SLEEP_SECONDS" -gt 0 ]; then
+        sleep "$POD_TRUNK_POST_PUBLISH_SLEEP_SECONDS"
+      fi
+      return 0
+    fi
+
+    echo "$pod_name ($pod_version) not yet visible on trunk after attempt $attempt"
+    attempt=$((attempt + 1))
+    if [ $attempt -le $POD_TRUNK_MAX_ATTEMPTS ]; then
+      sleep "$POD_TRUNK_RETRY_DELAY_SECONDS"
+    fi
+  done
+
+  echo "Failed to push $pod_name after $POD_TRUNK_MAX_ATTEMPTS attempts"
+  return 1
+}

--- a/.github/workflows/scripts/test/lib/assert.sh
+++ b/.github/workflows/scripts/test/lib/assert.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+TEST_ASSERT_PASSED=0
+TEST_ASSERT_FAILED=0
+TEST_ASSERT_CURRENT=""
+
+test_start() {
+  TEST_ASSERT_CURRENT=$1
+}
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local message=${3:-}
+
+  if [ "$expected" = "$actual" ]; then
+    TEST_ASSERT_PASSED=$((TEST_ASSERT_PASSED + 1))
+    echo "  ok: $TEST_ASSERT_CURRENT${message:+ ($message)}"
+    return 0
+  fi
+
+  TEST_ASSERT_FAILED=$((TEST_ASSERT_FAILED + 1))
+  echo "  FAIL: $TEST_ASSERT_CURRENT"
+  echo "        expected: $expected"
+  echo "        actual:   $actual"
+  if [ -n "$message" ]; then
+    echo "        note:     $message"
+  fi
+  return 1
+}
+
+assert_contains() {
+  local haystack=$1
+  local needle=$2
+  local message=${3:-}
+
+  if [[ "$haystack" == *"$needle"* ]]; then
+    TEST_ASSERT_PASSED=$((TEST_ASSERT_PASSED + 1))
+    echo "  ok: $TEST_ASSERT_CURRENT${message:+ ($message)}"
+    return 0
+  fi
+
+  TEST_ASSERT_FAILED=$((TEST_ASSERT_FAILED + 1))
+  echo "  FAIL: $TEST_ASSERT_CURRENT"
+  echo "        expected output to contain: $needle"
+  if [ -n "$message" ]; then
+    echo "        note: $message"
+  fi
+  return 1
+}
+
+assert_not_contains() {
+  local haystack=$1
+  local needle=$2
+  local message=${3:-}
+
+  if [[ "$haystack" != *"$needle"* ]]; then
+    TEST_ASSERT_PASSED=$((TEST_ASSERT_PASSED + 1))
+    echo "  ok: $TEST_ASSERT_CURRENT${message:+ ($message)}"
+    return 0
+  fi
+
+  TEST_ASSERT_FAILED=$((TEST_ASSERT_FAILED + 1))
+  echo "  FAIL: $TEST_ASSERT_CURRENT"
+  echo "        expected output NOT to contain: $needle"
+  if [ -n "$message" ]; then
+    echo "        note: $message"
+  fi
+  return 1
+}
+
+assert_file_exists() {
+  local file_path=$1
+  local message=${2:-}
+
+  if [ -f "$file_path" ]; then
+    TEST_ASSERT_PASSED=$((TEST_ASSERT_PASSED + 1))
+    echo "  ok: $TEST_ASSERT_CURRENT${message:+ ($message)}"
+    return 0
+  fi
+
+  TEST_ASSERT_FAILED=$((TEST_ASSERT_FAILED + 1))
+  echo "  FAIL: $TEST_ASSERT_CURRENT"
+  echo "        missing file: $file_path"
+  return 1
+}
+
+assert_exit_code() {
+  local expected=$1
+  local actual=$2
+  assert_eq "$expected" "$actual" "exit code"
+}
+
+assert_suite_summary() {
+  local suite_name=$1
+  echo ""
+  echo "Suite $suite_name: $TEST_ASSERT_PASSED passed, $TEST_ASSERT_FAILED failed"
+}
+
+reset_assert_counters() {
+  TEST_ASSERT_PASSED=0
+  TEST_ASSERT_FAILED=0
+  TEST_ASSERT_CURRENT=""
+}

--- a/.github/workflows/scripts/test/lib/mock-bin.sh
+++ b/.github/workflows/scripts/test/lib/mock-bin.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+mock_bin_init() {
+  MOCK_BIN_DIR=$(mktemp -d)
+  export MOCK_BIN_DIR
+  MOCK_STATE_DIR=$(mktemp -d)
+  export MOCK_STATE_DIR
+  export PATH="$MOCK_BIN_DIR:$PATH"
+
+  : >"$MOCK_STATE_DIR/trunk_push.log"
+  : >"$MOCK_STATE_DIR/repo_add.log"
+  : >"$MOCK_STATE_DIR/repo_update.log"
+  : >"$MOCK_STATE_DIR/spec_queries.log"
+  : >"$MOCK_STATE_DIR/curl_urls.log"
+  : >"$MOCK_STATE_DIR/specs.txt"
+  echo 0 >"$MOCK_STATE_DIR/trunk_push_failures_remaining"
+
+  MOCK_TRUNK_PUSH_FAILS=${MOCK_TRUNK_PUSH_FAILS:-0}
+  MOCK_TRUNK_PUSH_EXIT=${MOCK_TRUNK_PUSH_EXIT:-1}
+  MOCK_REPO_HAS_COCOAPODS=${MOCK_REPO_HAS_COCOAPODS:-1}
+  MOCK_VISIBLE_AFTER_PUSH=${MOCK_VISIBLE_AFTER_PUSH:-0}
+  echo "$MOCK_TRUNK_PUSH_FAILS" >"$MOCK_STATE_DIR/trunk_push_failures_remaining"
+  export MOCK_TRUNK_PUSH_EXIT MOCK_REPO_HAS_COCOAPODS MOCK_VISIBLE_AFTER_PUSH MOCK_STATE_DIR
+
+  mock_install_all
+}
+
+mock_bin_teardown() {
+  if [ -n "${MOCK_BIN_DIR:-}" ] && [ -d "$MOCK_BIN_DIR" ]; then
+    rm -rf "$MOCK_BIN_DIR"
+  fi
+  if [ -n "${MOCK_STATE_DIR:-}" ] && [ -d "$MOCK_STATE_DIR" ]; then
+    rm -rf "$MOCK_STATE_DIR"
+  fi
+}
+
+mock_add_spec() {
+  local pod_name=$1
+  local pod_version=$2
+  echo "$pod_name $pod_version" >>"$MOCK_STATE_DIR/specs.txt"
+}
+
+mock_install_pod() {
+  cat >"$MOCK_BIN_DIR/pod" <<'EOF'
+#!/bin/bash
+set -o pipefail
+
+case "$1" in
+  repo)
+    case "$2" in
+      list)
+        if [ "$MOCK_REPO_HAS_COCOAPODS" = "1" ]; then
+          echo "cocoapods"
+          echo "- Type: git (master)"
+        fi
+        exit 0
+        ;;
+      add)
+        echo "mock pod repo add $3" >>"$MOCK_STATE_DIR/repo_add.log"
+        exit 0
+        ;;
+      update)
+        echo "mock pod repo update ${3:-}" >>"$MOCK_STATE_DIR/repo_update.log"
+        exit 0
+        ;;
+    esac
+    ;;
+  spec)
+    if [ "$2" = "which" ]; then
+      pod_name=$3
+      shift 3
+      pod_version=""
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --version=*)
+            pod_version=${1#--version=}
+            ;;
+          --version)
+            shift
+            pod_version=$1
+            ;;
+        esac
+        shift
+      done
+      echo "query $pod_name $pod_version" >>"$MOCK_STATE_DIR/spec_queries.log"
+      if grep -qx "$pod_name $pod_version" "$MOCK_STATE_DIR/specs.txt"; then
+        echo "/mock/specs/$pod_name/$pod_version.podspec.json"
+        exit 0
+      fi
+      echo "[!] Can't find spec for $pod_name." >&2
+      exit 1
+    fi
+    ;;
+  trunk)
+    if [ "$2" = "push" ]; then
+      podspec_file=$3
+      echo "trunk push $podspec_file" >>"$MOCK_STATE_DIR/trunk_push.log"
+      remaining=$(cat "$MOCK_STATE_DIR/trunk_push_failures_remaining")
+      if [ "$remaining" -gt 0 ]; then
+        echo $((remaining - 1)) >"$MOCK_STATE_DIR/trunk_push_failures_remaining"
+        exit "$MOCK_TRUNK_PUSH_EXIT"
+      fi
+      if [ "$MOCK_VISIBLE_AFTER_PUSH" = "1" ]; then
+        base_name=$(basename "$podspec_file" .podspec)
+        echo "$base_name 1.0.0-test" >>"$MOCK_STATE_DIR/specs.txt"
+      fi
+      exit 0
+    fi
+    ;;
+esac
+
+echo "mock pod: unsupported command: $*" >&2
+exit 127
+EOF
+  chmod +x "$MOCK_BIN_DIR/pod"
+}
+
+mock_install_curl() {
+  local real_curl
+  real_curl=$(command -v curl)
+
+  cat >"$MOCK_BIN_DIR/curl" <<EOF
+#!/bin/bash
+set -o pipefail
+
+if [ "\${MOCK_CURL_FORCE_FAIL:-0}" = "1" ]; then
+  exit 22
+fi
+
+for arg in "\$@"; do
+  case "\$arg" in
+    http://*|https://*)
+      echo "\$arg" >>"$MOCK_STATE_DIR/curl_urls.log"
+      ;;
+  esac
+done
+
+if [ -n "\${MOCK_CURL_FAIL_PATTERN:-}" ]; then
+  for arg in "\$@"; do
+    if [[ "\$arg" == *"\$MOCK_CURL_FAIL_PATTERN"* ]]; then
+      current=\$(cat "$MOCK_STATE_DIR/curl_fail_count" 2>/dev/null || echo 0)
+      if [ "\$current" -lt "\${MOCK_CURL_FAIL_UNTIL:-0}" ]; then
+        echo \$((current + 1)) >"$MOCK_STATE_DIR/curl_fail_count"
+        exit 22
+      fi
+    fi
+  done
+fi
+
+exec "$real_curl" "\$@"
+EOF
+  chmod +x "$MOCK_BIN_DIR/curl"
+}
+
+mock_install_git() {
+  local real_git
+  real_git=$(command -v git)
+
+  cat >"$MOCK_BIN_DIR/git" <<EOF
+#!/bin/bash
+set -o pipefail
+
+if [[ "\$*" == *"push"* ]] || [[ "\$*" == *"commit"* ]] || [[ "\$*" == *" tag"* ]] || [[ "\$1" == "tag" ]]; then
+  echo "mock git blocked mutating command: git \$*" >&2
+  exit 1
+fi
+
+exec "$real_git" "\$@"
+EOF
+  chmod +x "$MOCK_BIN_DIR/git"
+}
+
+mock_install_sleep() {
+  cat >"$MOCK_BIN_DIR/sleep" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$MOCK_BIN_DIR/sleep"
+}
+
+mock_install_all() {
+  mock_install_pod
+  mock_install_curl
+  mock_install_git
+  mock_install_sleep
+}
+
+mock_trunk_push_count() {
+  wc -l <"$MOCK_STATE_DIR/trunk_push.log" | tr -d ' '
+}
+
+mock_repo_add_count() {
+  wc -l <"$MOCK_STATE_DIR/repo_add.log" | tr -d ' '
+}

--- a/.github/workflows/scripts/test/run-tests.sh
+++ b/.github/workflows/scripts/test/run-tests.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPTS_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+REPO_ROOT=$(cd "$SCRIPTS_DIR/../../.." && pwd)
+export REPO_ROOT
+
+# shellcheck source=lib/assert.sh
+source "$SCRIPT_DIR/lib/assert.sh"
+# shellcheck source=lib/mock-bin.sh
+source "$SCRIPT_DIR/lib/mock-bin.sh"
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+SELECTED_SUITE=${1:-all}
+
+run_suite() {
+  local suite_file=$1
+  local suite_name
+  suite_name=$(basename "$suite_file" .sh)
+  reset_assert_counters
+  # shellcheck source=/dev/null
+  source "$suite_file"
+  case "$suite_name" in
+    static) suite_static ;;
+    check-release-complete) suite_check_release_complete ;;
+    extract-versions) suite_extract_versions ;;
+    write-firestore-privacy-manifest) suite_write_firestore_privacy_manifest ;;
+    create-zips) suite_create_zips ;;
+    release-lib) suite_release_lib ;;
+    framework-controller) suite_framework_controller ;;
+    *)
+      echo "No runner registered for suite: $suite_name" >&2
+      exit 2
+      ;;
+  esac
+  TOTAL_PASSED=$((TOTAL_PASSED + TEST_ASSERT_PASSED))
+  TOTAL_FAILED=$((TOTAL_FAILED + TEST_ASSERT_FAILED))
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [suite]
+
+Suites:
+  all                         Run every suite (default)
+  static
+  check-release-complete
+  extract-versions
+  write-firestore-privacy-manifest
+  create-zips
+  release-lib
+  framework-controller
+
+These tests are read-only with respect to GitHub and CocoaPods trunk.
+They use temp directories and mocked git/pod/curl where mutation would occur.
+EOF
+}
+
+case "$SELECTED_SUITE" in
+  all)
+    run_suite "$SCRIPT_DIR/suites/static.sh"
+    run_suite "$SCRIPT_DIR/suites/check-release-complete.sh"
+    run_suite "$SCRIPT_DIR/suites/extract-versions.sh"
+    run_suite "$SCRIPT_DIR/suites/write-firestore-privacy-manifest.sh"
+    run_suite "$SCRIPT_DIR/suites/create-zips.sh"
+    run_suite "$SCRIPT_DIR/suites/release-lib.sh"
+    run_suite "$SCRIPT_DIR/suites/framework-controller.sh"
+    ;;
+  static|check-release-complete|extract-versions|write-firestore-privacy-manifest|create-zips|release-lib|framework-controller)
+    run_suite "$SCRIPT_DIR/suites/$SELECTED_SUITE.sh"
+    ;;
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown suite: $SELECTED_SUITE" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+echo ""
+echo "========================================"
+echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "========================================"
+
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/scripts/test/suites/check-release-complete.sh
+++ b/.github/workflows/scripts/test/suites/check-release-complete.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+suite_check_release_complete() {
+  echo "=== Suite: check-release-complete.sh ==="
+  local script="$SCRIPTS_DIR/check-release-complete.sh"
+  local output
+  local exit_code
+
+  test_start "complete release exits 0"
+  set +e
+  output=$(bash "$script" 12.16.0 1.69.0 1.2024072200.0 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_contains "$output" "already complete"
+
+  test_start "missing tag exits 1"
+  set +e
+  output=$(bash "$script" 99.99.99 1.69.0 1.2024072200.0 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 1 "$exit_code"
+  assert_contains "$output" "does not exist"
+
+  test_start "missing pod exits 1"
+  set +e
+  output=$(bash "$script" 12.16.0 9.99.9 1.2024072200.0 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 1 "$exit_code"
+  assert_contains "$output" "not on CocoaPods trunk"
+
+  test_start "missing args exits 2"
+  set +e
+  output=$(bash "$script" 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 2 "$exit_code"
+  assert_contains "$output" "Missing firebase_firestore_version"
+
+  assert_suite_summary "check-release-complete"
+}

--- a/.github/workflows/scripts/test/suites/create-zips.sh
+++ b/.github/workflows/scripts/test/suites/create-zips.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+start_local_http_server() {
+  local serve_dir=$1
+  local port
+  port=$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)
+  python3 -m http.server "$port" --directory "$serve_dir" >/dev/null 2>&1 &
+  LOCAL_HTTP_SERVER_PID=$!
+  LOCAL_HTTP_SERVER_PORT=$port
+  sleep 1
+}
+
+stop_local_http_server() {
+  if [ -n "${LOCAL_HTTP_SERVER_PID:-}" ]; then
+    kill "$LOCAL_HTTP_SERVER_PID" >/dev/null 2>&1 || true
+    wait "$LOCAL_HTTP_SERVER_PID" 2>/dev/null || true
+  fi
+}
+
+suite_create_zips() {
+  echo "=== Suite: create-zips.sh ==="
+  local script="$SCRIPTS_DIR/create-zips.sh"
+  local workdir
+  local output
+  local exit_code
+  local privacy_url
+  local zip_url
+  local serve_dir
+
+  workdir=$(mktemp -d)
+  serve_dir="$workdir/serve"
+  mkdir -p "$serve_dir" "$workdir/Archives" "$workdir/tmp"
+  pushd "$workdir" >/dev/null
+
+  echo "payload" >"$serve_dir/content.txt"
+  (cd "$serve_dir" && zip -q tiny.zip content.txt)
+  printf '%s\n' \
+    '<?xml version="1.0" encoding="UTF-8"?>' \
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+    '<plist version="1.0"><dict/></plist>' \
+    >"$serve_dir/PrivacyInfo.xcprivacy"
+
+  start_local_http_server "$serve_dir"
+  zip_url="http://127.0.0.1:${LOCAL_HTTP_SERVER_PORT}/tiny.zip"
+  privacy_url="http://127.0.0.1:${LOCAL_HTTP_SERVER_PORT}/PrivacyInfo.xcprivacy"
+
+  test_start "creates zip with privacy manifest from local HTTP server"
+  set +e
+  output=$(bash "$script" "$zip_url" "$privacy_url" "./Archives/test.zip" 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_file_exists "Archives/test.zip"
+  assert_contains "$output" "New ZIP file created"
+
+  test_start "uses curl retry flags in script"
+  assert_contains "$(cat "$script")" "--retry 5"
+  assert_contains "$(cat "$script")" "--retry-all-errors"
+
+  test_start "fails when download never succeeds"
+  mock_bin_init
+  MOCK_CURL_FORCE_FAIL=1
+  export MOCK_CURL_FORCE_FAIL
+  set +e
+  output=$(bash "$script" "$zip_url" "$privacy_url" "./Archives/fail.zip" 2>&1)
+  exit_code=$?
+  set -e
+  mock_bin_teardown
+  unset MOCK_CURL_FORCE_FAIL
+  assert_exit_code 1 "$exit_code"
+  assert_contains "$output" "Failed to download"
+
+  stop_local_http_server
+  popd >/dev/null
+  rm -rf "$workdir"
+
+  assert_suite_summary "create-zips"
+}

--- a/.github/workflows/scripts/test/suites/extract-versions.sh
+++ b/.github/workflows/scripts/test/suites/extract-versions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+suite_extract_versions() {
+  echo "=== Suite: extract-versions.sh ==="
+  local script="$SCRIPTS_DIR/extract-versions.sh"
+  local workdir
+  local output
+  local exit_code
+  local versions_file
+  local github_env_file
+
+  workdir=$(mktemp -d)
+  versions_file="$workdir/versions.json"
+  github_env_file="$workdir/github.env"
+
+  pushd "$workdir" >/dev/null
+  mkdir -p tmp
+
+  test_start "writes valid version JSON"
+  set +e
+  output=$(GITHUB_ENV="$github_env_file" bash "$script" "$versions_file" 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_file_exists "$versions_file"
+  latest_version=$(python3 - "$versions_file" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+required = [
+  "firebase_firestore_version",
+  "firebase_firestore_grpc_version",
+  "firebase_firestore_leveldb_version",
+  "firebase_firestore_nanopb_version",
+  "firebase_firestore_abseil_version",
+]
+for key in required:
+    assert data.get(key), f"missing {key}"
+print(data["firebase_firestore_version"])
+PY
+)
+  assert_contains "$output" "Latest Firebase Firestore version: $latest_version"
+
+  test_start "writes LATEST_FIREBASE_VERSION to GITHUB_ENV"
+  assert_file_exists "$github_env_file"
+  assert_contains "$(cat "$github_env_file")" "LATEST_FIREBASE_VERSION=$latest_version"
+
+  test_start "repo-add guard skips add when cocoapods repo exists (mocked)"
+  mock_bin_init
+  MOCK_REPO_HAS_COCOAPODS=1
+  export MOCK_REPO_HAS_COCOAPODS
+  set +e
+  output=$(bash -c '
+    if ! pod repo list 2>/dev/null | grep -qE "^cocoapods$"; then
+      pod repo add cocoapods "https://github.com/CocoaPods/Specs.git"
+    fi
+    pod repo update cocoapods
+  ' 2>&1)
+  exit_code=$?
+  repo_add_count=$(mock_repo_add_count)
+  mock_bin_teardown
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_eq 0 "$repo_add_count" "repo add not called"
+  assert_not_contains "$output" "destination path"
+
+  popd >/dev/null
+  rm -rf "$workdir"
+
+  assert_suite_summary "extract-versions"
+}

--- a/.github/workflows/scripts/test/suites/framework-controller.sh
+++ b/.github/workflows/scripts/test/suites/framework-controller.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+suite_framework_controller() {
+  echo "=== Suite: framework-controller.dart ==="
+  local output
+  local exit_code
+  local github_env_file
+  local start_ts
+  local elapsed
+
+  github_env_file=$(mktemp)
+
+  test_start "early-exits for already complete release"
+  start_ts=$(date +%s)
+  set +e
+  output=$(cd "$REPO_ROOT" && GITHUB_ENV="$github_env_file" dart "$SCRIPTS_DIR/framework-controller.dart" 2>&1)
+  exit_code=$?
+  set -e
+  elapsed=$(( $(date +%s) - start_ts ))
+  assert_exit_code 0 "$exit_code"
+  assert_contains "$output" "already complete; skipping build"
+  assert_contains "$(cat "$github_env_file")" "LATEST_FIREBASE_VERSION="
+  assert_not_contains "$output" "New ZIP file created"
+
+  test_start "early-exit completes quickly"
+  if [ "$elapsed" -lt 900 ]; then
+    assert_eq "fast" "fast" "completed in ${elapsed}s"
+  else
+    assert_eq "fast" "slow" "took ${elapsed}s; expected early exit under 900s"
+  fi
+
+  rm -f "$github_env_file"
+
+  assert_suite_summary "framework-controller"
+}

--- a/.github/workflows/scripts/test/suites/release-lib.sh
+++ b/.github/workflows/scripts/test/suites/release-lib.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+suite_release_lib() {
+  echo "=== Suite: release-lib.sh / push_pod_if_missing ==="
+  local output
+  local exit_code
+
+  POD_TRUNK_MAX_ATTEMPTS=3
+  POD_TRUNK_RETRY_DELAY_SECONDS=0
+  POD_TRUNK_POST_PUBLISH_SLEEP_SECONDS=0
+  export POD_TRUNK_MAX_ATTEMPTS POD_TRUNK_RETRY_DELAY_SECONDS POD_TRUNK_POST_PUBLISH_SLEEP_SECONDS
+
+  test_start "already published pod skips trunk push"
+  mock_bin_init
+  mock_add_spec "FirebaseFirestoreBinary" "12.16.0"
+  # shellcheck source=../../release-lib.sh
+  source "$SCRIPTS_DIR/release-lib.sh"
+  set +e
+  output=$(push_pod_if_missing FirebaseFirestoreBinary 12.16.0 FirebaseFirestoreBinary.podspec 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_contains "$output" "already exists"
+  assert_eq 0 "$(mock_trunk_push_count)"
+  mock_bin_teardown
+
+  test_start "false-negative trunk push still succeeds when spec appears"
+  mock_bin_init
+  MOCK_TRUNK_PUSH_FAILS=1
+  MOCK_TRUNK_PUSH_EXIT=1
+  MOCK_VISIBLE_AFTER_PUSH=1
+  echo 1 >"$MOCK_STATE_DIR/trunk_push_failures_remaining"
+  export MOCK_TRUNK_PUSH_FAILS MOCK_TRUNK_PUSH_EXIT MOCK_VISIBLE_AFTER_PUSH
+  # shellcheck source=../../release-lib.sh
+  source "$SCRIPTS_DIR/release-lib.sh"
+  set +e
+  output=$(push_pod_if_missing FirebaseFirestoreBinary 1.0.0-test FirebaseFirestoreBinary.podspec 2>&1)
+  exit_code=$?
+  trunk_push_count=$(mock_trunk_push_count)
+  mock_bin_teardown
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_contains "$output" "confirmed on CocoaPods trunk"
+  assert_eq 2 "$trunk_push_count" "push attempted twice before spec visible"
+
+  test_start "true failure exits non-zero after max attempts"
+  mock_bin_init
+  MOCK_TRUNK_PUSH_FAILS=99
+  MOCK_VISIBLE_AFTER_PUSH=0
+  echo 99 >"$MOCK_STATE_DIR/trunk_push_failures_remaining"
+  export MOCK_TRUNK_PUSH_FAILS MOCK_VISIBLE_AFTER_PUSH
+  # shellcheck source=../../release-lib.sh
+  source "$SCRIPTS_DIR/release-lib.sh"
+  set +e
+  output=$(push_pod_if_missing FirebaseFirestoreBinary 9.9.9 FirebaseFirestoreBinary.podspec 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 1 "$exit_code"
+  assert_contains "$output" "Failed to push FirebaseFirestoreBinary"
+  assert_eq 3 "$(mock_trunk_push_count)"
+  mock_bin_teardown
+
+  test_start "ensure_cocoapods_repo skips add when repo exists"
+  mock_bin_init
+  MOCK_REPO_HAS_COCOAPODS=1
+  export MOCK_REPO_HAS_COCOAPODS
+  # shellcheck source=../../release-lib.sh
+  source "$SCRIPTS_DIR/release-lib.sh"
+  ensure_cocoapods_repo
+  assert_eq 0 "$(mock_repo_add_count)"
+  mock_bin_teardown
+
+  test_start "ensure_cocoapods_repo adds repo when missing"
+  mock_bin_init
+  MOCK_REPO_HAS_COCOAPODS=0
+  export MOCK_REPO_HAS_COCOAPODS
+  # shellcheck source=../../release-lib.sh
+  source "$SCRIPTS_DIR/release-lib.sh"
+  ensure_cocoapods_repo
+  assert_eq 1 "$(mock_repo_add_count)"
+  mock_bin_teardown
+
+  assert_suite_summary "release-lib"
+}

--- a/.github/workflows/scripts/test/suites/static.sh
+++ b/.github/workflows/scripts/test/suites/static.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+suite_static() {
+  echo "=== Suite: static checks ==="
+
+  test_start "dart analyze passes"
+  if (cd "$SCRIPTS_DIR" && dart pub get >/dev/null 2>&1 && dart analyze >/dev/null 2>&1); then
+    assert_eq 0 0 "dart analyze"
+  else
+    assert_eq 0 1 "dart analyze"
+  fi
+
+  if command -v shellcheck >/dev/null 2>&1; then
+    test_start "shellcheck passes for modified release scripts"
+    if shellcheck -x -e SC1091,SC2086,SC2034,SC2155 \
+      "$SCRIPTS_DIR/release-lib.sh" \
+      "$SCRIPTS_DIR/check-release-complete.sh" \
+      "$SCRIPTS_DIR/write-firestore-privacy-manifest.sh" \
+      "$SCRIPTS_DIR/create-zips.sh" \
+      "$SCRIPTS_DIR/commit-and-publish.sh" \
+      "$SCRIPTS_DIR/extract-versions.sh" \
+      "$SCRIPT_DIR/lib/assert.sh" \
+      "$SCRIPT_DIR/lib/mock-bin.sh" \
+      "$SCRIPT_DIR/run-tests.sh" \
+      >/dev/null 2>&1; then
+      assert_eq 0 0 "shellcheck"
+    else
+      shellcheck -x -e SC1091,SC2086,SC2034,SC2155 \
+        "$SCRIPTS_DIR/release-lib.sh" \
+        "$SCRIPTS_DIR/check-release-complete.sh" \
+        "$SCRIPTS_DIR/write-firestore-privacy-manifest.sh" \
+        "$SCRIPTS_DIR/create-zips.sh" \
+        "$SCRIPTS_DIR/commit-and-publish.sh" \
+        "$SCRIPTS_DIR/extract-versions.sh" \
+        "$SCRIPT_DIR/lib/assert.sh" \
+        "$SCRIPT_DIR/lib/mock-bin.sh" \
+        "$SCRIPT_DIR/run-tests.sh"
+      assert_eq 0 1 "shellcheck"
+    fi
+  else
+    test_start "shellcheck available"
+    echo "  skip: shellcheck not installed"
+  fi
+
+  assert_suite_summary "static"
+}

--- a/.github/workflows/scripts/test/suites/write-firestore-privacy-manifest.sh
+++ b/.github/workflows/scripts/test/suites/write-firestore-privacy-manifest.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+suite_write_firestore_privacy_manifest() {
+  echo "=== Suite: write-firestore-privacy-manifest.sh ==="
+  local script="$SCRIPTS_DIR/write-firestore-privacy-manifest.sh"
+  local workdir
+  local output
+  local exit_code
+
+  workdir=$(mktemp -d)
+  pushd "$workdir" >/dev/null
+
+  test_start "downloads valid plist for 12.16.0"
+  set +e
+  output=$(bash "$script" 12.16.0 2>&1)
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code"
+  assert_file_exists "Resources/FirebaseFirestore.xcprivacy"
+  assert_contains "$(head -3 Resources/FirebaseFirestore.xcprivacy)" "<?xml version=\"1.0\""
+  assert_contains "$output" "valid plist/XML file"
+
+  rm -rf Resources
+
+  test_start "fails on HTTP error without saving junk plist"
+  mock_bin_init
+  MOCK_CURL_FORCE_FAIL=1
+  export MOCK_CURL_FORCE_FAIL
+  set +e
+  output=$(bash "$script" 12.16.0 2>&1)
+  exit_code=$?
+  set -e
+  mock_bin_teardown
+  unset MOCK_CURL_FORCE_FAIL
+  assert_exit_code 1 "$exit_code"
+  if [ -f Resources/FirebaseFirestore.xcprivacy ]; then
+    assert_not_contains "$(cat Resources/FirebaseFirestore.xcprivacy)" "<plist"
+  else
+    assert_eq "missing" "missing" "no junk file written"
+  fi
+
+  popd >/dev/null
+  rm -rf "$workdir"
+
+  assert_suite_summary "write-firestore-privacy-manifest"
+}

--- a/.github/workflows/scripts/utils.dart
+++ b/.github/workflows/scripts/utils.dart
@@ -200,3 +200,15 @@ Future<void> createZip(
 String createURLToZip(String zipName, String firebaseSdkVersion) {
   return 'https://github.com/invertase/firestore-ios-sdk-frameworks/raw/$firebaseSdkVersion/Archives/$zipName.zip';
 }
+
+Future<void> exportLatestFirebaseVersion(String version) async {
+  final githubEnv = Platform.environment['GITHUB_ENV'];
+  if (githubEnv == null) {
+    return;
+  }
+
+  await File(githubEnv).writeAsString(
+    'LATEST_FIREBASE_VERSION=$version\n',
+    mode: FileMode.append,
+  );
+}

--- a/.github/workflows/scripts/write-firestore-privacy-manifest.sh
+++ b/.github/workflows/scripts/write-firestore-privacy-manifest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 firebase_firestore_version=$1
 
@@ -12,21 +13,18 @@ local_file_path="$local_dir/FirebaseFirestore.xcprivacy"
 # Create the local directory if it doesn't exist
 mkdir -p "$local_dir"
 
-# Download the file and write to the local directory
-curl -L -v "$url" -o "$local_file_path"
-
-# Check if the file was created successfully
-if [[ -f "$local_file_path" ]]; then
-    echo "File downloaded successfully and written to $local_file_path"
-else
-    echo "Failed to download the file."
-    exit 1
+# Download the file and fail on HTTP errors (e.g. 504 HTML responses).
+if ! curl -sfL --retry 5 --retry-delay 10 --retry-all-errors "$url" -o "$local_file_path"; then
+  echo "Failed to download the file from $url"
+  exit 1
 fi
+
+echo "File downloaded successfully and written to $local_file_path"
 
 # Check if the file is a plist/XML file
 if grep -q "<?xml version=\"1.0\"" "$local_file_path" && grep -q "<plist" "$local_file_path"; then
-    echo "FirebaseFirestore privacy manifest downloaded successfully and is a valid plist/XML file."
+  echo "FirebaseFirestore privacy manifest downloaded successfully and is a valid plist/XML file."
 else
-    echo "The downloaded file is not a valid plist/XML file."
-    exit 1
+  echo "The downloaded file is not a valid plist/XML file."
+  exit 1
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .idea
 .vscode
 .tmp
+tmp/
 pubspec.lock
 package_config.json


### PR DESCRIPTION
## Summary

- Skip the full build when the git tag and all six CocoaPods specs already exist on trunk.
- Retry pod trunk push and verify with `pod spec which` so GitHub commit API timeouts are not treated as publish failures.
- Use `curl -sfL` with retries for privacy manifest, zip, and Package.swift downloads so HTTP errors (e.g. 504 HTML) fail fast.
- Skip `pod repo add` when the `cocoapods` repo is already registered.
- Export `LATEST_FIREBASE_VERSION` to `GITHUB_ENV` and include it in Slack failure alerts.
- Add a self-contained release-script test harness (47 assertions, no git/trunk side effects).
- Ignore `tmp/` scratch output from CI scripts.

## Test plan

- [x] `bash .github/workflows/scripts/test/run-tests.sh` (47 passed locally)
- [ ] Merge and verify scheduled/workflow_dispatch CI early-exits cleanly for 12.16.0