### PR TITLE
build(deps): macos-latest runner / update all workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,30 +12,34 @@ jobs:
 
     name: "Latest Release"
     timeout-minutes: 120
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      # https://github.com/actions/checkout/releases
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: GIT Setup
         run: |
           git fetch --tags
           git config --global user.name 'Invertase Publisher'
           git config --global user.email 'oss@invertase.io'
           git remote set-url origin git@github.com:$GITHUB_REPOSITORY
-      - uses: webfactory/ssh-agent@v0.9.1
+      # https://github.com/webfactory/ssh-agent/releases
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         if: ${{ github.repository == 'invertase/firestore-ios-sdk-frameworks' }}
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set Github Token Securely
         if: ${{ github.repository == 'invertase/firestore-ios-sdk-frameworks' }}
         run: echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN }}" >> $GITHUB_ENV
-      - uses: dart-lang/setup-dart@v1
+      # https://github.com/dart-lang/setup-dart/releases
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       - run: cd ./.github/workflows/scripts && dart pub get
       - name: Process Latest Version
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: dart ./.github/workflows/scripts/framework-controller.dart
       - name: Report Failure Status
-        uses: slackapi/slack-github-action@v2
+        # https://github.com/slackapi/slack-github-action/releases
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: failure()
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions in `build.yml` to latest release SHAs with version comments (react-native-firebase style)
- Move runner from `macos-15` to `macos-latest` (currently macos-26)

## Actions updated
| Action | Prior | New |
|--------|-------|-----|
| `actions/checkout` | `@v4` | v7.0.0 |
| `webfactory/ssh-agent` | v0.9.1 | v0.10.0 |
| `dart-lang/setup-dart` | `@v1` | v1.7.2 |
| `slackapi/slack-github-action` | `@v2` | v3.0.3 |

No workflow input changes required; release push path already uses SSH via `webfactory/ssh-agent`.

## Test plan
- [x] CI passes on this PR
- [ ] Optional: `workflow_dispatch` smoke run on merge